### PR TITLE
Save when filename not provided through cli

### DIFF
--- a/main.py
+++ b/main.py
@@ -64,7 +64,7 @@ status_bar_field = VSplit([Window(FormattedTextControl(get_datetime()))], height
 def _no_filename_save(event):
     global filename
     filename = event.text
-    with open(event.text, 'wt') as f:
+    with open(event.text, "wt") as f:
         f.write(text_field.text)
     ApplicationState.show_status_bar = True
     ApplicationState.ask_for_filename = False
@@ -74,7 +74,10 @@ def _no_filename_save(event):
 
 
 filename_prompt_field_text = TextArea(
-    scrollbar=False, line_numbers=False, multiline=False, accept_handler=_no_filename_save
+    scrollbar=False,
+    line_numbers=False,
+    multiline=False,
+    accept_handler=_no_filename_save,
 )
 
 filename_prompt_field = VSplit(
@@ -116,7 +119,6 @@ def _save_file(event) -> None:
         ApplicationState.show_status_bar = False
         ApplicationState.ask_for_filename = True
         get_app().layout.focus(filename_prompt_field_text)
-
 
 
 @bindings.add("c-c")

--- a/main.py
+++ b/main.py
@@ -4,18 +4,13 @@ from datetime import datetime
 
 from prompt_toolkit.application import Application
 from prompt_toolkit.application.current import get_app
+from prompt_toolkit.filters import Condition
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.layout.containers import (
     ConditionalContainer,
     HSplit,
     VSplit,
     Window,
-)
-from prompt_toolkit.filters import Condition
-from prompt_toolkit.widgets import (
-    MenuContainer,
-    MenuItem,
-    TextArea,
 )
 from prompt_toolkit.layout.controls import FormattedTextControl
 from prompt_toolkit.layout.layout import Layout
@@ -26,8 +21,10 @@ from pygments.lexers.python import PythonLexer
 
 
 class ApplicationState:
-    "Application state"
+    """Application state"""
+
     show_status_bar = True
+    ask_for_filename = False
 
 
 def get_text_from_file(filename):
@@ -38,11 +35,7 @@ def get_text_from_file(filename):
     return text
 
 
-def get_datetime():
-    return "Opened at " + datetime.now().strftime("%d/%m/%Y, %H:%M:%S")
-
-
-# Parsing Argumemnts
+# Parsing Arguments
 parser = argparse.ArgumentParser()
 parser.add_argument("filename", nargs="?")
 args = vars(parser.parse_args())
@@ -61,12 +54,33 @@ text_field = TextArea(
 
 # Status bar area
 def get_datetime():
-    "Get opening datetime"
+    """Get opening datetime"""
     return "Opened at " + datetime.now().strftime("%d/%m/%Y, %H:%M:%S")
 
 
 status_bar_field = VSplit([Window(FormattedTextControl(get_datetime()))], height=1)
 
+
+def _no_filename_save(event):
+    global filename
+    filename = event.text
+    with open(event.text, 'wt') as f:
+        f.write(text_field.text)
+    ApplicationState.show_status_bar = True
+    ApplicationState.ask_for_filename = False
+    get_app().layout.focus(text_field)
+
+    return True
+
+
+filename_prompt_field_text = TextArea(
+    scrollbar=False, line_numbers=False, multiline=False, accept_handler=_no_filename_save
+)
+
+filename_prompt_field = VSplit(
+    [Window(FormattedTextControl("Path To Save File: ")), filename_prompt_field_text],
+    height=1,
+)
 
 # UI main body
 body = HSplit(
@@ -76,9 +90,12 @@ body = HSplit(
             content=status_bar_field,
             filter=Condition(lambda: ApplicationState.show_status_bar),
         ),
+        ConditionalContainer(
+            content=filename_prompt_field,
+            filter=Condition(lambda: ApplicationState.ask_for_filename),
+        ),
     ]
 )
-
 
 # Keybindings
 bindings = KeyBindings()
@@ -86,7 +103,7 @@ bindings = KeyBindings()
 
 @bindings.add("c-d")
 def _exit(event):
-    "Exit the text editor"
+    """Exit the text editor"""
     event.app.exit()
 
 
@@ -95,11 +112,16 @@ def _save_file(event) -> None:
     if filename is not None:
         with open(filename, "w") as f:
             f.write(text_field.text)
+    else:
+        ApplicationState.show_status_bar = False
+        ApplicationState.ask_for_filename = True
+        get_app().layout.focus(filename_prompt_field_text)
+
 
 
 @bindings.add("c-c")
 def _focus(event):
-    "Focus on the menu"
+    """Focus on the menu"""
     event.app.layout.focus(root_container.window)
 
 
@@ -125,16 +147,10 @@ root_container = MenuContainer(
     key_bindings=bindings,
 )
 
-
 layout = Layout(root_container, focused_element=text_field)
 
 # Global style
-style = Style.from_dict(
-    {
-        # empty for now
-    }
-)
-
+style = Style.from_dict({})  # empty for now
 
 application = Application(
     layout=layout,


### PR DESCRIPTION
Allows saving through a prompt if the file name wasn't provided in the command line arguments
Known Issues:
After the prompt closes, the time opened is always shown